### PR TITLE
add migrations to Docker image

### DIFF
--- a/docker/Dockerfile.prod
+++ b/docker/Dockerfile.prod
@@ -17,5 +17,8 @@ WORKDIR /usr/src/app
 
 COPY --from=builder /usr/src/app/build ./
 COPY --from=builder /usr/src/app/node_modules ./node_modules
+COPY  ./migrations/ ./migrations/
+COPY  migrate-mongo-config.js ./
+COPY  package.json ./
 
 CMD ["node", "index.js"]


### PR DESCRIPTION
It is necessary to put migrations to Docker image to have the ability to run their on deploying